### PR TITLE
Updated specfile. Works under mock for EL6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,17 +95,12 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/broccoli-config.in
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 add_definitions(-DHAVE_CONFIG_H)
 
-IF(UNIX AND NOT WIN32 AND NOT APPLE)
-  IF(CMAKE_SIZEOF_VOID_P MATCHES "8")
-      SET(LIB_POSTFIX "64" CACHE STRING "suffix for 32/64 dir placement")
-      MARK_AS_ADVANCED(LIB_POSTFIX)
-  ENDIF()
-ENDIF()
-IF(NOT DEFINED LIB_POSTFIX)
-    SET(LIB_POSTFIX "")
-ENDIF()
+# Offer the user the choice of overriding the installation directories
+set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
 
-set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_POSTFIX}")
+if (NOT IS_ABSOLUTE "${INSTALL_LIB_DIR}")
+    set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}")
+endif()
 
 ########################################################################
 ## Install Files
@@ -162,7 +157,7 @@ message(
     "\n=================|  Broccoli Build Summary  |==================="
     "\n"
     "\nInstall prefix:    ${CMAKE_INSTALL_PREFIX}"
-    "\nLibrary prefix:    ${LIB_INSTALL_DIR}"
+    "\nLibrary prefix:    ${INSTALL_LIB_DIR}"
     "\nDebug mode:        ${ENABLE_DEBUG}"
     "\nShared libs:       ${ENABLE_SHARED}"
     "\nStatic libs:       ${ENABLE_STATIC}"

--- a/broccoli.spec
+++ b/broccoli.spec
@@ -24,8 +24,7 @@ turns Bro into a distributed policy-controlled event management system.
 %setup -q
 
 %build
-./configure --prefix=/usr --conf-files-dir=%{_sysconfdir}/bro --python-install-dir=%{python_sitearch}
-#cd build && #cmake .. <-- I'd rather use this
+./configure --prefix=%{_prefix} --libdir=%{_libdir} --conf-files-dir=%{_sysconfdir}/bro --python-install-dir=%{python_sitearch}
 make %{?_smp_mflags}
 
 %install

--- a/configure
+++ b/configure
@@ -25,6 +25,8 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --python-install-dir   the desired installation directory for
                            broccoli python bindings (if present)
                            [PREFIX/lib/python]
+    --libdir=DIR           installation directory for static and dynamic
+                           libraries [PREFIX/lib]
 
   Optional Features:
     --enable-debug         compile in debugging mode
@@ -86,6 +88,7 @@ prefix=/usr/local
 CMakeCacheEntries=""
 append_cache_entry CMAKE_INSTALL_PREFIX PATH     $prefix
 append_cache_entry PY_MOD_INSTALL_DIR   PATH     $prefix/lib/python
+append_cache_entry INSTALL_LIB_DIR      PATH     $prefix/lib
 append_cache_entry ENABLE_DEBUG         BOOL     false
 append_cache_entry BRO_PCAP_SUPPORT     BOOL     true
 append_cache_entry CPACK_SOURCE_IGNORE_FILES STRING
@@ -109,6 +112,11 @@ while [ $# -ne 0 ]; do
             prefix=$optarg
             append_cache_entry CMAKE_INSTALL_PREFIX PATH   $optarg
             append_cache_entry PY_MOD_INSTALL_DIR   PATH   $optarg/lib/python
+            append_cache_entry INSTALL_LIB_DIR      PATH   $optarg/lib
+            ;;
+        --libdir=*)
+            libdir=$optarg
+            append_cache_entry INSTALL_LIB_DIR      PATH   $optarg
             ;;
         --conf-files-dir=*)
             append_cache_entry BRO_ETC_INSTALL_DIR  PATH   $optarg

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,14 +82,14 @@ if (ENABLE_SHARED)
         # Mac OS X needs the directory portion of the install_name
         # shared lib field
         set_target_properties(broccoli PROPERTIES
-                              INSTALL_NAME_DIR ${LIB_INSTALL_DIR})
+                              INSTALL_NAME_DIR ${INSTALL_LIB_DIR})
     endif ()
     # BIND library is not necessary, but linked when a parent project
     # uses it (for consistency and also to avoid missing inet_* symbols
     # that can result from mismatching headers/libraries)
     target_link_libraries(broccoli ${OpenSSL_LIBRARIES} ${BIND_LIBRARY}
                           ${BRO_LIBADD})
-    install(TARGETS broccoli DESTINATION ${LIB_INSTALL_DIR})
+    install(TARGETS broccoli DESTINATION ${INSTALL_LIB_DIR})
 endif ()
 
 if (ENABLE_STATIC)
@@ -104,7 +104,7 @@ if (ENABLE_STATIC)
     # that can result from mismatching headers/libraries)
     target_link_libraries(broccoliStatic ${OpenSSL_LIBRARIES} ${BIND_LIBRARY}
                           ${BRO_LIBADD})
-    install(TARGETS broccoliStatic DESTINATION ${LIB_INSTALL_DIR})
+    install(TARGETS broccoliStatic DESTINATION ${INSTALL_LIB_DIR})
 endif ()
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/broccoli.h DESTINATION include)


### PR DESCRIPTION
I'd like to be able to package the bro collection using spec files, rather than using the cludgy cpack approach. This still isn't quite perfect, but it is able to create the equivalent to the existing spec file.

Things To Do (I'll circle back to these once I get a "functional" bro build)
- Find cleaner way to accept the arguments from the RPM macros %configure or %cmake -- Possibly just give a warning on "unknown" arguments and massage the rest into the ./configure script
- Split package into proper broccoli, broccoli-devel, broccoli-python, broccoli-ruby packages.
