### PR TITLE
Removed hostname and date from line 25 of CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if (UNIX)
 else ()
     set(builddate "build date not available")
 endif ()
-set(BUILDINFO "${hostname}, ${builddate}, Debugging support: ${ENABLE_DEBUG}")
+set(BUILDINFO "Debugging support: ${ENABLE_DEBUG}")
 
 # if no static/shared library preference is given, default to building both
 if (NOT DEFINED ENABLE_SHARED)


### PR DESCRIPTION
Hi!

As part of the reproducible builds (https://reproducible-builds.org/), the package being built on different systems will produce different results (since hostname/date is different). Removing the two from the buildinfo should fix the problem.

Issue: https://tests.reproducible-builds.org/debian/rb-pkg/unstable/i386/broccoli.html
Differences in builds when built on different systems: https://tests.reproducible-builds.org/debian/rb-pkg/unstable/i386/diffoscope-results/broccoli.html

Thank you!